### PR TITLE
Added frames to fswebcam

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ var opts = {
 
     quality: 100,
 
+    // Number of frames to capture
+    // More the frames, longer it takes to capture
+    // Use higher framerate for quality. Ex: 60
+
+    frames: 60,
+
 
     //Delay in seconds to take shot
     //if the platform supports miliseconds

--- a/src/webcams/FSWebcam.js
+++ b/src/webcams/FSWebcam.js
@@ -76,6 +76,11 @@ FSWebcam.prototype.generateSh = function( location ) {
     var resolution = " -r "
         + scope.opts.width + "x" + scope.opts.height;
 
+    // Adding frame rate
+    var frames = scope.opts.frames
+        ? "-F " + scope.opts.frames
+        : "";
+
     var output = "--" + scope.opts.output;
 
     var quality = scope.opts.quality;
@@ -125,6 +130,7 @@ FSWebcam.prototype.generateSh = function( location ) {
     var sh = scope.bin + " "
         + verbose + " "
         + resolution + " "
+        + frames + " "
         + output + " "
         + quality + " "
         + delay + " "


### PR DESCRIPTION
Added frames to options object to capture frame rate and pass it to capture function. This will be added to the command only if provided in options.
**fswebcam   -r 1024x768 -F -120 --jpeg 100     --no-banner   img.jpg**