### PR TITLE
Support for multiple cameras in listControls API

### DIFF
--- a/bin/node-webcam.js
+++ b/bin/node-webcam.js
@@ -124,7 +124,7 @@ function main() {
 
     if( parsedOpts.listControls ) {
 
-        return listControls();
+        return listControls(parsedOpts.device);
 
     }
 
@@ -192,11 +192,11 @@ function list() {
 
 }
 
-function listControls() {
+function listControls(device) {
 
     NodeWebcam.listControls(function(controls) {
         console.log("Listing Controls");
         console.log(controls);
-    });
+    }, device);
 
 }

--- a/index.js
+++ b/index.js
@@ -109,11 +109,13 @@ NodeWebcam.list = function( callback ) {
  *
  * @param {Function(Array<CameraControl>)} callback
  *
+ * @param {String} device
+ *
  */
 
-NodeWebcam.listControls = function( callback ) {
+NodeWebcam.listControls = function( callback, device ) {
 
-    var cam = NodeWebcam.create({});
+    var cam = NodeWebcam.create({device});
 
     cam.listControls(callback);
 

--- a/src/webcams/FSWebcam.js
+++ b/src/webcams/FSWebcam.js
@@ -194,7 +194,9 @@ FSWebcam.prototype.getListControlsSh = function() {
 
     var scope = this;
 
-    return scope.bin + " --list-controls";
+    var devSwitch = scope.opts.device ? " --device=" + scope.opts.device.trim() : "";
+
+    return scope.bin + devSwitch + " --list-controls";
 
 }
 


### PR DESCRIPTION
This commit fixes an oversight in the previous listControls API contribution, which only worked for the default camera; now any camera specified in the options (command line or programmatically) is honored.