### PR TITLE
Incorrect warning

### DIFF
--- a/src/Webcam.js
+++ b/src/Webcam.js
@@ -206,7 +206,7 @@ Webcam.prototype = {
         if(
             location === null
             && scope.opts.callbackReturn ===
-                Webcam.CallbackReturnTypes.buffer
+                Webcam.CallbackReturnTypes.location
         ) {
 
             console.warn(


### PR DESCRIPTION
The warning says `If capturing image in memory your callback return type cannot be the location`, but the code checks for 
`scope.opts.callbackReturn === Webcam.CallbackReturnTypes.buffer`. My proposed change should be what was intended, right?